### PR TITLE
Add toggles for enabling/disabling address families

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/pages/index.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/index.tsx
@@ -34,7 +34,17 @@ export default function HomePage() {
     kadenaAddress,
     bip122Address,
     smartAccountEnabled,
-    chainAbstractionEnabled
+    chainAbstractionEnabled,
+    eip155Enabled,
+    polkadotEnabled,
+    solanaEnabled,
+    nearEnabled,
+    cosmosEnabled,
+    multiversxEnabled,
+    tronEnabled,
+    tezosEnabled,
+    kadenaEnabled,
+    bip122Enabled
   } = useSnapshot(SettingsStore.state)
   const { getAvailableSmartAccounts } = useSmartAccounts()
   const { push } = useRouter()
@@ -47,234 +57,252 @@ export default function HomePage() {
       <Text h4 css={{ marginBottom: '$5' }}>
         Mainnets
       </Text>
-      {Object.entries(POLKADOT_MAINNET_CHAINS).map(([caip10, { name, logo, rgb, ss58Format }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={encodeAddress(polkadotAddress, ss58Format)}
-          chainId={caip10}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
-      {Object.entries(EIP155_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={eip155Address}
-          chainId={caip10.toString()}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
-      {Object.entries(COSMOS_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={cosmosAddress}
-          chainId={caip10}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
-      {Object.entries(SOLANA_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={solanaAddress}
-          chainId={caip10}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
-      {Object.entries(MULTIVERSX_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={multiversxAddress}
-          chainId={caip10}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
-      {Object.entries(TRON_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={tronAddress}
-          chainId={caip10}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
-      {Object.entries(TEZOS_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={tezosAddress}
-          chainId={caip10}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
-      {Object.entries(KADENA_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={kadenaAddress}
-          chainId={caip10}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
-      {Object.entries(BIP122_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-        <AccountCard
-          key={name}
-          name={name}
-          logo={logo}
-          rgb={rgb}
-          address={bip122Address}
-          chainId={caip10}
-          data-testid={'chain-card-' + caip10.toString()}
-        />
-      ))}
+      {polkadotEnabled &&
+        Object.entries(POLKADOT_MAINNET_CHAINS).map(([caip10, { name, logo, rgb, ss58Format }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={encodeAddress(polkadotAddress, ss58Format)}
+            chainId={caip10}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
+      {eip155Enabled &&
+        Object.entries(EIP155_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={eip155Address}
+            chainId={caip10.toString()}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
+      {cosmosEnabled &&
+        Object.entries(COSMOS_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={cosmosAddress}
+            chainId={caip10}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
+      {solanaEnabled &&
+        Object.entries(SOLANA_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={solanaAddress}
+            chainId={caip10}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
+      {multiversxEnabled &&
+        Object.entries(MULTIVERSX_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={multiversxAddress}
+            chainId={caip10}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
+      {tronEnabled &&
+        Object.entries(TRON_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={tronAddress}
+            chainId={caip10}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
+      {tezosEnabled &&
+        Object.entries(TEZOS_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={tezosAddress}
+            chainId={caip10}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
+      {kadenaEnabled &&
+        Object.entries(KADENA_MAINNET_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={kadenaAddress}
+            chainId={caip10}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
+      {bip122Enabled &&
+        Object.entries(BIP122_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+          <AccountCard
+            key={name}
+            name={name}
+            logo={logo}
+            rgb={rgb}
+            address={bip122Address}
+            chainId={caip10}
+            data-testid={'chain-card-' + caip10.toString()}
+          />
+        ))}
 
       {testNets ? (
         <Fragment>
           <Text h4 css={{ marginBottom: '$5' }}>
             Testnets
           </Text>
-          {Object.entries(POLKADOT_TEST_CHAINS).map(([caip10, { name, logo, rgb, ss58Format }]) => (
-            <AccountCard
-              key={name}
-              name={name}
-              logo={logo}
-              rgb={rgb}
-              address={encodeAddress(polkadotAddress, ss58Format)}
-              chainId={caip10}
-              data-testid={'chain-card-' + caip10.toString()}
-            />
-          ))}
-          {Object.entries(EIP155_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-            <AccountCard
-              key={name}
-              name={name}
-              logo={logo}
-              rgb={rgb}
-              address={eip155Address}
-              chainId={caip10.toString()}
-              data-testid={'chain-card-' + caip10.toString()}
-            />
-          ))}
-          {Object.entries(EIP155_TEST_CHAINS).map(([caip10, { name, logo, rgb, chainId }]) => {
-            if (smartAccountEnabled) {
-              return (
-                <div key={`${name}-smart`} style={{ marginBottom: 10 }}>
-                  {getAvailableSmartAccounts()
-                    .filter(account => {
-                      return account.chain.id === chainId
-                    })
-                    .map(account => {
-                      return (
-                        <div
-                          style={{ marginBottom: 10, cursor: 'pointer' }}
-                          key={`${name}-${account.type.toLowerCase()}`}
-                          onClick={() =>
-                            push({
-                              pathname: `/accounts/${account.type}:${chainId}:${account.address}`
-                            })
-                          }
-                        >
-                          <AccountCard
+          {polkadotEnabled &&
+            Object.entries(POLKADOT_TEST_CHAINS).map(([caip10, { name, logo, rgb, ss58Format }]) => (
+              <AccountCard
+                key={name}
+                name={name}
+                logo={logo}
+                rgb={rgb}
+                address={encodeAddress(polkadotAddress, ss58Format)}
+                chainId={caip10}
+                data-testid={'chain-card-' + caip10.toString()}
+              />
+            ))}
+          {eip155Enabled &&
+            Object.entries(EIP155_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+              <AccountCard
+                key={name}
+                name={name}
+                logo={logo}
+                rgb={rgb}
+                address={eip155Address}
+                chainId={caip10.toString()}
+                data-testid={'chain-card-' + caip10.toString()}
+              />
+            ))}
+          {eip155Enabled &&
+            Object.entries(EIP155_TEST_CHAINS).map(([caip10, { name, logo, rgb, chainId }]) => {
+              if (smartAccountEnabled) {
+                return (
+                  <div key={`${name}-smart`} style={{ marginBottom: 10 }}>
+                    {getAvailableSmartAccounts()
+                      .filter(account => {
+                        return account.chain.id === chainId
+                      })
+                      .map(account => {
+                        return (
+                          <div
+                            style={{ marginBottom: 10, cursor: 'pointer' }}
                             key={`${name}-${account.type.toLowerCase()}`}
-                            name={`${account.type} Smart Account \n ${name}`}
-                            logo={logo}
-                            rgb={rgb}
-                            address={account.address}
-                            chainId={caip10.toString()}
-                            data-testid={`chain-card-${caip10.toString()}-${account.type.toLowerCase()}`}
-                          />
-                        </div>
-                      )
-                    })}
-                </div>
-              )
-            }
-          })}
-          {Object.entries(SOLANA_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-            <AccountCard
-              key={name}
-              name={name}
-              logo={logo}
-              rgb={rgb}
-              address={solanaAddress}
-              chainId={caip10}
-              data-testid={'chain-card-' + caip10.toString()}
-            />
-          ))}
-          {Object.entries(NEAR_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-            <AccountCard
-              key={name}
-              name={name}
-              logo={logo}
-              rgb={rgb}
-              address={nearAddress}
-              chainId={caip10}
-              data-testid={'chain-card-' + caip10.toString()}
-            />
-          ))}
-          {Object.entries(MULTIVERSX_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-            <AccountCard
-              key={name}
-              name={name}
-              logo={logo}
-              rgb={rgb}
-              address={multiversxAddress}
-              chainId={caip10}
-              data-testid={'chain-card-' + caip10.toString()}
-            />
-          ))}
-          {Object.entries(TRON_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-            <AccountCard
-              key={name}
-              name={name}
-              logo={logo}
-              rgb={rgb}
-              address={tronAddress}
-              chainId={caip10}
-              data-testid={'chain-card-' + caip10.toString()}
-            />
-          ))}
-          {Object.entries(TEZOS_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-            <AccountCard
-              key={name}
-              name={name}
-              logo={logo}
-              rgb={rgb}
-              address={tezosAddress}
-              chainId={caip10}
-              data-testid={'chain-card-' + caip10.toString()}
-            />
-          ))}
-          {Object.entries(KADENA_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
-            <AccountCard
-              key={name}
-              name={name}
-              logo={logo}
-              rgb={rgb}
-              address={kadenaAddress}
-              chainId={caip10}
-              data-testid={'chain-card-' + caip10.toString()}
-            />
-          ))}
+                            onClick={() =>
+                              push({
+                                pathname: `/accounts/${account.type}:${chainId}:${account.address}`
+                              })
+                            }
+                          >
+                            <AccountCard
+                              key={`${name}-${account.type.toLowerCase()}`}
+                              name={`${account.type} Smart Account \n ${name}`}
+                              logo={logo}
+                              rgb={rgb}
+                              address={account.address}
+                              chainId={caip10.toString()}
+                              data-testid={`chain-card-${caip10.toString()}-${account.type.toLowerCase()}`}
+                            />
+                          </div>
+                        )
+                      })}
+                  </div>
+                )
+              }
+            })}
+          {solanaEnabled &&
+            Object.entries(SOLANA_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+              <AccountCard
+                key={name}
+                name={name}
+                logo={logo}
+                rgb={rgb}
+                address={solanaAddress}
+                chainId={caip10}
+                data-testid={'chain-card-' + caip10.toString()}
+              />
+            ))}
+          {nearEnabled &&
+            Object.entries(NEAR_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+              <AccountCard
+                key={name}
+                name={name}
+                logo={logo}
+                rgb={rgb}
+                address={nearAddress}
+                chainId={caip10}
+                data-testid={'chain-card-' + caip10.toString()}
+              />
+            ))}
+          {multiversxEnabled &&
+            Object.entries(MULTIVERSX_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+              <AccountCard
+                key={name}
+                name={name}
+                logo={logo}
+                rgb={rgb}
+                address={multiversxAddress}
+                chainId={caip10}
+                data-testid={'chain-card-' + caip10.toString()}
+              />
+            ))}
+          {tronEnabled &&
+            Object.entries(TRON_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+              <AccountCard
+                key={name}
+                name={name}
+                logo={logo}
+                rgb={rgb}
+                address={tronAddress}
+                chainId={caip10}
+                data-testid={'chain-card-' + caip10.toString()}
+              />
+            ))}
+          {tezosEnabled &&
+            Object.entries(TEZOS_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+              <AccountCard
+                key={name}
+                name={name}
+                logo={logo}
+                rgb={rgb}
+                address={tezosAddress}
+                chainId={caip10}
+                data-testid={'chain-card-' + caip10.toString()}
+              />
+            ))}
+          {kadenaEnabled &&
+            Object.entries(KADENA_TEST_CHAINS).map(([caip10, { name, logo, rgb }]) => (
+              <AccountCard
+                key={name}
+                name={name}
+                logo={logo}
+                rgb={rgb}
+                address={kadenaAddress}
+                chainId={caip10}
+                data-testid={'chain-card-' + caip10.toString()}
+              />
+            ))}
         </Fragment>
       ) : null}
     </Fragment>

--- a/advanced/wallets/react-wallet-v2/src/pages/settings.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/settings.tsx
@@ -29,7 +29,17 @@ export default function SettingsPage() {
     safeSmartAccountEnabled,
     biconomySmartAccountEnabled,
     moduleManagementEnabled,
-    chainAbstractionEnabled
+    chainAbstractionEnabled,
+    eip155Enabled,
+    polkadotEnabled,
+    solanaEnabled,
+    nearEnabled,
+    cosmosEnabled,
+    multiversxEnabled,
+    tronEnabled,
+    tezosEnabled,
+    kadenaEnabled,
+    bip122Enabled
   } = useSnapshot(SettingsStore.state)
 
   return (
@@ -172,6 +182,96 @@ export default function SettingsPage() {
           ) : (
             <Text color="$gray400">This feature requires testnets</Text>
           )}
+        </Col>
+      </Row>
+
+      <Divider y={2} />
+
+      <Row>
+        <Col>
+          <Text h4 css={{ marginBottom: '$5' }}>
+            Address Families
+          </Text>
+          <Row justify="space-between" align="center">
+            <Text>EIP155</Text>
+            <Switch
+              checked={eip155Enabled}
+              onChange={SettingsStore.toggleEip155Enabled}
+              data-testid="settings-toggle-eip155"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>Polkadot</Text>
+            <Switch
+              checked={polkadotEnabled}
+              onChange={SettingsStore.togglePolkadotEnabled}
+              data-testid="settings-toggle-polkadot"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>Solana</Text>
+            <Switch
+              checked={solanaEnabled}
+              onChange={SettingsStore.toggleSolanaEnabled}
+              data-testid="settings-toggle-solana"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>Near</Text>
+            <Switch
+              checked={nearEnabled}
+              onChange={SettingsStore.toggleNearEnabled}
+              data-testid="settings-toggle-near"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>Cosmos</Text>
+            <Switch
+              checked={cosmosEnabled}
+              onChange={SettingsStore.toggleCosmosEnabled}
+              data-testid="settings-toggle-cosmos"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>MultiversX</Text>
+            <Switch
+              checked={multiversxEnabled}
+              onChange={SettingsStore.toggleMultiversxEnabled}
+              data-testid="settings-toggle-multiversx"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>Tron</Text>
+            <Switch
+              checked={tronEnabled}
+              onChange={SettingsStore.toggleTronEnabled}
+              data-testid="settings-toggle-tron"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>Tezos</Text>
+            <Switch
+              checked={tezosEnabled}
+              onChange={SettingsStore.toggleTezosEnabled}
+              data-testid="settings-toggle-tezos"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>Kadena</Text>
+            <Switch
+              checked={kadenaEnabled}
+              onChange={SettingsStore.toggleKadenaEnabled}
+              data-testid="settings-toggle-kadena"
+            />
+          </Row>
+          <Row justify="space-between" align="center">
+            <Text>BIP122</Text>
+            <Switch
+              checked={bip122Enabled}
+              onChange={SettingsStore.toggleBip122Enabled}
+              data-testid="settings-toggle-bip122"
+            />
+          </Row>
         </Col>
       </Row>
 

--- a/advanced/wallets/react-wallet-v2/src/store/SettingsStore.ts
+++ b/advanced/wallets/react-wallet-v2/src/store/SettingsStore.ts
@@ -15,6 +15,16 @@ const ZERO_DEV_SMART_ACCOUNTS_ENABLED_KEY = 'ZERO_DEV_SMART_ACCOUNTS'
 const SAFE_SMART_ACCOUNTS_ENABLED_KEY = 'SAFE_SMART_ACCOUNTS'
 const BICONOMY_SMART_ACCOUNTS_ENABLED_KEY = 'BICONOMY_SMART_ACCOUNTS'
 const MODULE_MANAGEMENT_ENABLED_KEY = 'MODULE_MANAGEMENT'
+const EIP155_ENABLED_KEY = 'EIP155_ENABLED'
+const POLKADOT_ENABLED_KEY = 'POLKADOT_ENABLED'
+const SOLANA_ENABLED_KEY = 'SOLANA_ENABLED'
+const NEAR_ENABLED_KEY = 'NEAR_ENABLED'
+const COSMOS_ENABLED_KEY = 'COSMOS_ENABLED'
+const MULTIVERSX_ENABLED_KEY = 'MULTIVERSX_ENABLED'
+const TRON_ENABLED_KEY = 'TRON_ENABLED'
+const TEZOS_ENABLED_KEY = 'TEZOS_ENABLED'
+const KADENA_ENABLED_KEY = 'KADENA_ENABLED'
+const BIP122_ENABLED_KEY = 'BIP122_ENABLED'
 
 /**
  * Types
@@ -46,6 +56,16 @@ interface State {
   biconomySmartAccountEnabled: boolean
   moduleManagementEnabled: boolean
   chainAbstractionEnabled: boolean
+  eip155Enabled: boolean
+  polkadotEnabled: boolean
+  solanaEnabled: boolean
+  nearEnabled: boolean
+  cosmosEnabled: boolean
+  multiversxEnabled: boolean
+  tronEnabled: boolean
+  tezosEnabled: boolean
+  kadenaEnabled: boolean
+  bip122Enabled: boolean
 }
 
 /**
@@ -95,7 +115,27 @@ const state = proxy<State>({
       ? Boolean(localStorage.getItem(MODULE_MANAGEMENT_ENABLED_KEY))
       : false,
   chainAbstractionEnabled:
-    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(CA_ENABLED_KEY)) : false
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(CA_ENABLED_KEY)) : false,
+  eip155Enabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(EIP155_ENABLED_KEY)) : true,
+  polkadotEnabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(POLKADOT_ENABLED_KEY)) : true,
+  solanaEnabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(SOLANA_ENABLED_KEY)) : true,
+  nearEnabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(NEAR_ENABLED_KEY)) : true,
+  cosmosEnabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(COSMOS_ENABLED_KEY)) : true,
+  multiversxEnabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(MULTIVERSX_ENABLED_KEY)) : true,
+  tronEnabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(TRON_ENABLED_KEY)) : true,
+  tezosEnabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(TEZOS_ENABLED_KEY)) : true,
+  kadenaEnabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(KADENA_ENABLED_KEY)) : true,
+  bip122Enabled:
+    typeof localStorage !== 'undefined' ? Boolean(localStorage.getItem(BIP122_ENABLED_KEY)) : true
 })
 
 /**
@@ -262,6 +302,96 @@ const SettingsStore = {
       state.moduleManagementEnabled = false
       localStorage.removeItem(MODULE_MANAGEMENT_ENABLED_KEY)
       localStorage.removeItem(BICONOMY_SMART_ACCOUNTS_ENABLED_KEY)
+    }
+  },
+
+  toggleEip155Enabled() {
+    state.eip155Enabled = !state.eip155Enabled
+    if (state.eip155Enabled) {
+      localStorage.setItem(EIP155_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(EIP155_ENABLED_KEY)
+    }
+  },
+
+  togglePolkadotEnabled() {
+    state.polkadotEnabled = !state.polkadotEnabled
+    if (state.polkadotEnabled) {
+      localStorage.setItem(POLKADOT_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(POLKADOT_ENABLED_KEY)
+    }
+  },
+
+  toggleSolanaEnabled() {
+    state.solanaEnabled = !state.solanaEnabled
+    if (state.solanaEnabled) {
+      localStorage.setItem(SOLANA_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(SOLANA_ENABLED_KEY)
+    }
+  },
+
+  toggleNearEnabled() {
+    state.nearEnabled = !state.nearEnabled
+    if (state.nearEnabled) {
+      localStorage.setItem(NEAR_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(NEAR_ENABLED_KEY)
+    }
+  },
+
+  toggleCosmosEnabled() {
+    state.cosmosEnabled = !state.cosmosEnabled
+    if (state.cosmosEnabled) {
+      localStorage.setItem(COSMOS_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(COSMOS_ENABLED_KEY)
+    }
+  },
+
+  toggleMultiversxEnabled() {
+    state.multiversxEnabled = !state.multiversxEnabled
+    if (state.multiversxEnabled) {
+      localStorage.setItem(MULTIVERSX_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(MULTIVERSX_ENABLED_KEY)
+    }
+  },
+
+  toggleTronEnabled() {
+    state.tronEnabled = !state.tronEnabled
+    if (state.tronEnabled) {
+      localStorage.setItem(TRON_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(TRON_ENABLED_KEY)
+    }
+  },
+
+  toggleTezosEnabled() {
+    state.tezosEnabled = !state.tezosEnabled
+    if (state.tezosEnabled) {
+      localStorage.setItem(TEZOS_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(TEZOS_ENABLED_KEY)
+    }
+  },
+
+  toggleKadenaEnabled() {
+    state.kadenaEnabled = !state.kadenaEnabled
+    if (state.kadenaEnabled) {
+      localStorage.setItem(KADENA_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(KADENA_ENABLED_KEY)
+    }
+  },
+
+  toggleBip122Enabled() {
+    state.bip122Enabled = !state.bip122Enabled
+    if (state.bip122Enabled) {
+      localStorage.setItem(BIP122_ENABLED_KEY, 'YES')
+    } else {
+      localStorage.removeItem(BIP122_ENABLED_KEY)
     }
   }
 }


### PR DESCRIPTION
Add toggles for enabling/disabling different address families on the settings page and update the index page to conditionally display accounts based on these toggles.

* **Settings Page (`settings.tsx`)**
  - Add toggles for enabling/disabling eip155, polkadot, solana, near, cosmos, multiversx, tron, tezos, kadena, and bip122 address families.
  - Update the `SettingsStore` state and actions to handle the new toggles.

* **Settings Store (`SettingsStore.ts`)**
  - Add state variables for enabling/disabling eip155, polkadot, solana, near, cosmos, multiversx, tron, tezos, kadena, and bip122 address families.
  - Add actions to toggle the state variables for the new address families.

* **Index Page (`index.tsx`)**
  - Conditionally display accounts based on the enabled/disabled state of eip155, polkadot, solana, near, cosmos, multiversx, tron, tezos, kadena, and bip122 address families.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/btwiuse/walletconnect-v2-examples/pull/19?shareId=6e527da1-f602-489a-b2a1-47760f4487c1).