### PR TITLE
Fix the PWA icon to appear on iOS

### DIFF
--- a/advanced/wallets/react-wallet-v2/src/pages/_app.tsx
+++ b/advanced/wallets/react-wallet-v2/src/pages/_app.tsx
@@ -34,6 +34,10 @@ export default function App({ Component, pageProps }: AppProps) {
       <Head>
         <link rel="manifest" type="application/manifest+json" href="/manifest.json" />
         <meta name="theme-color" content="#000000" />
+        <meta name="mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-capable" content="yes" />
+        <meta name="apple-mobile-web-app-title" content="WalletConnect" />
+        <link rel="apple-touch-icon" href="./wallet-connect-logo-300x300.png" />
       </Head>
       <Layout initialized={initialized}>
         <Toaster />


### PR DESCRIPTION
Add necessary meta tags and apple-touch-icon link for iOS PWA compatibility.

* **Manifest File Changes:**
  - Add `apple-touch-icon` link with the src `./wallet-connect-logo-300x300.png`.
  - Add meta tags for iOS PWA compatibility including `mobile-web-app-capable`, `apple-mobile-web-app-capable`, `apple-mobile-web-app-title`, and `apple-touch-icon`.

* **App File Changes:**
  - Add meta tags in the `<head>` section including `mobile-web-app-capable`, `apple-mobile-web-app-capable`, `apple-mobile-web-app-title`.
  - Add link tag for `apple-touch-icon` in the `<head>` section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/btwiuse/walletconnect-v2-examples/pull/21?shareId=86614260-c26a-4509-b4fb-a230f592b23b).